### PR TITLE
Fix symlink issue by replacing get_full_path_or_raise with get_full_path

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -37,9 +37,11 @@ class LoadLotusModel:
         dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[precision]
         mm.soft_empty_cache()
 
-        lotus_model_path = folder_paths.get_full_path_or_raise("diffusion_models", model)
+        model_path = folder_paths.get_full_path("diffusion_models", model)
+        if not model_path or not os.path.exists(model_path):
+            raise FileNotFoundError(f"Model file not found: {model}")
         
-        lotus_sd = load_torch_file(lotus_model_path)
+        lotus_sd = load_torch_file(model_path)
         in_channels = lotus_sd['conv_in.weight'].shape[1]
         lotus_config = os.path.join(script_directory, "configs", "lotus_unet_config.json")
 


### PR DESCRIPTION
### Summary
I had Claude fix this issue for me with this PR and its been working perfectly.

This pull request addresses an issue where the `folder_paths` module does not have a method named `get_full_path_or_raise`. This method is used in the `LoadLotusModel` class to retrieve the full path of the model file. The absence of this method causes a `ModuleNotFoundError` when the models folder is symlinked.

### Changes Made
1. **Replaced `get_full_path_or_raise` with `get_full_path`:** The `folder_paths.get_full_path` method is used to get the full path of the model file.
2. **Added a check to ensure the file exists:** If the file does not exist, a `FileNotFoundError` is raised with an appropriate message.

### Detailed Changes
- **File:** `custom_nodes/ComfyUI-Lotus/nodes.py`
- **Class:** `LoadLotusModel`
- **Method:** `loadmodel`
